### PR TITLE
Fix missing mouth on welcome

### DIFF
--- a/face.py
+++ b/face.py
@@ -120,8 +120,6 @@ class View(Gtk.EventBox):
         self.status = Status()
         self.fill_color = fill_color
 
-        self.connect('size-allocate', self._size_allocate_cb)
-
         self._audio = speech.get_speech()
 
         # make an empty box for some eyes
@@ -132,6 +130,7 @@ class View(Gtk.EventBox):
         # make an empty box to put the mouth in
         self._mouth = None
         self._mouthbox = Gtk.HBox()
+        self._mouthbox.set_size_request(-1, style.GRID_CELL_SIZE * 10 / 2.5)
         self._mouthbox.show()
 
         # layout the screen
@@ -231,6 +230,3 @@ class View(Gtk.EventBox):
 
     def shut_up(self):
         self._audio.stop_sound_device()
-
-    def _size_allocate_cb(self, widget, allocation):
-        self._mouthbox.set_size_request(-1, int(allocation.height // 2.5))

--- a/mouth.py
+++ b/mouth.py
@@ -45,7 +45,7 @@ class Mouth(Gtk.DrawingArea):
         self.audio = None
 
     def draw_cb(self, widget, cr):
-        pass
+        return True
 
 
 class PeakMouth(Mouth):

--- a/mouth.py
+++ b/mouth.py
@@ -27,11 +27,14 @@ import cairo
 
 from gi.repository import Gtk
 
+from sugar3.graphics import style
+
 
 class Mouth(Gtk.DrawingArea):
     def __init__(self, audio, fill_color):
 
         Gtk.DrawingArea.__init__(self)
+        self.set_size_request(-1, style.GRID_CELL_SIZE * 4)
 
         self.fill_color = fill_color
         self.audio = audio

--- a/mouth.py
+++ b/mouth.py
@@ -36,9 +36,7 @@ class Mouth(Gtk.DrawingArea):
         self.fill_color = fill_color
         self.audio = audio
 
-        def realize_cb(widget):
-            widget.connect("draw", self.draw_cb)
-        self.connect("realize", realize_cb)
+        self.connect("draw", self.draw_cb)
 
     def stop(self):
         self.audio.disconnect_all()


### PR DESCRIPTION
Mouth was missing for the welcome utterance.
    
Cause was mismanagement of the size after port to GTK 3; it was one pixel height during the welcome.

Mouth was designed for one on two and a half times or 40% of the available height.

Instead of recalculating it when the canvas resizes, set a size request in proportion to the style grid cell size.

Fixes https://github.com/sugarlabs/speak/issues/21

Tested on Ubuntu 19.04 with Sugar 0.116
