### PR TITLE
Fix support for non-english languages

### DIFF
--- a/voice.py
+++ b/voice.py
@@ -73,6 +73,12 @@ _allVoices = {}
 _defaultVoice = None
 
 
+def _friendly_name(full_name):
+    parts = re.split('[ _-]', full_name)
+    short_name = _(parts[0].capitalize())
+    return ' '.join([short_name] + parts[1:])
+
+
 class Voice:
     def __init__(self, language, name):
         self.language = language
@@ -115,11 +121,15 @@ def allVoices():
         voice = Voice(language, name)
         _allVoices[voice.friendlyname] = voice
 
-    if 'English' not in _allVoices:
-        _allVoices['English'] = _allVoices['English (America)']
+    en_name = _friendly_name('English')
+    if en_name not in _allVoices:
+        _allVoices[en_name] = _allVoices[_friendly_name('English (America)')]
+        _allVoices[en_name].friendlyname = en_name
 
-    if 'Spanish' not in _allVoices:
-        _allVoices['Spanish'] = _allVoices['Spanish (Latin America)']
+    es_name = _friendly_name('Spanish')
+    if es_name not in _allVoices:
+        _allVoices[es_name] = _allVoices[_friendly_name('Spanish (Latin America)')]
+        _allVoices[es_name].friendlyname = es_name
 
     return _allVoices
 
@@ -154,9 +164,9 @@ def defaultVoice():
         lang = ""
 
     voice_names = [
-        "English (America)",  # espeak-ng 1.49.2
-        "English",  # espeak-ng 1.49.1
-        "Default",  # espeak 1.48
+        _friendly_name("English (America)"),  # espeak-ng 1.49.2
+        _friendly_name("English"),  # espeak-ng 1.49.1
+        _friendly_name("Default"),  # espeak 1.48
     ]
 
     best = None
@@ -165,15 +175,19 @@ def defaultVoice():
             best = voices[voice_name]
             break
 
+    es_name = _friendly_name('Spanish')
+    es_la_name = _friendly_name('Spanish (Latin America)')
+    en_au_name = _friendly_name('English (Received Pronunciation)')
+
     for voice in list(voices.values()):
         voiceMetric = fit(voice.language, lang)
         bestMetric = fit(best.language, lang)
         if lang == 'en_AU.UTF-8':
-            if voice.friendlyname == 'English (Received Pronunciation)':
+            if voice.friendlyname == en_au_name:
                 best = voice
                 break
         if lang[0:2] == 'es':
-            if voice.friendlyname in ['Spanish', 'Spanish (Latin America)']:
+            if voice.friendlyname in [es_name, es_la_name]:
                 best = voice
                 break
         if voiceMetric > bestMetric:


### PR DESCRIPTION
In Voice.__init__ we are translating half of the language name,
but on later comparisons we are not translating these names at
all.

Is not enough to translate these names, but to translate them
in a consistent way. Add a private function to do that.

Plus, when we create the English and Spanish fallbaks we must
ensure that both dict keys and friendlyname values are equal.