### PR TITLE
Demo for LLM in the chatbot

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -84,6 +84,8 @@ from faceselect import FaceSelector
 
 import speech
 
+from gradio_client import Client #not adding this to readme and not mentioning as a requirement as this is just a demo and final product will not use this client
+
 SERVICE = 'org.sugarlabs.Speak'
 IFACE = SERVICE
 PATH = '/org/sugarlabs/Speak'
@@ -165,6 +167,18 @@ def _is_tablet_mode():
         return True
     return False
 
+def llm_response(query, modelname = "Qwen/Qwen2.5-Max-Demo"):
+        client = Client(modelname)
+        result = client.predict(
+                query=query,
+                history=[],
+                system='''You a chatbot for an educational kids app.
+                  Your primary function is to teach kids how to pronounce words right.
+                  You must also answer their questions in a simple manner, in no more than 20-30 words.
+                  You must guide the learner on how to better improve their learning and remind them from time to time about trying new words and explain their meaning.''',
+                api_name="/model_chat"
+        )
+        return result[1][0][1]
 
 class SpeakActivity(activity.Activity):
     def __init__(self, handle):
@@ -964,8 +978,10 @@ class SpeakActivity(activity.Activity):
             self.face.look_ahead()
 
             # speak the text
-            if self._mode == MODE_BOT:
-                self.face.say(brain.respond(text))
+            if self._mode == MODE_BOT: #this sends the text to the chatbot
+                self.face.say("Please wait while I think about this")
+                self.face.say(llm_response(text)) 
+
             else:
                 self.face.say(text)
 


### PR DESCRIPTION
## Summary:
The chatbot mode now sends the user entered text to an LLM, and speaks the response.

## How it works:
Added a function to call a pre-existing model on hugging face to use for the chatbot. This currently requires that the user has `gradio_client` installed via `pip`

## Testing:
- [x] Activity must start  
- [x] Activity must refresh entire display when focus is restored  
- [x] Activity must behave predictably (except where randomness is designed)  
- [x] Activity must save data to journal  
- [x] Activity must restore the saved data from journal (click on the journal entry)  
- [x] Other activities must be able to use saved data, if it is declared with the relevant content type  
- [x] Every coded feature should either work properly, or be removed if it cannot be fixed  
- [x] Collaboration support, if present, must function properly between two or more systems  
- [x] Activity should not consume all available battery power (e.g. pygame clock rate too high)  
- [x] Activity should not contain any security vulnerabilities  
- [x] Activity should not reveal personal information  

## Note:
This is done to test how the chatbot would perform by connecting with an api endpoint to answer queries. This is just a demo to test things for the upcoming GSoC '25. @chimosky @walterbender 
The end goal would be to use our own LLM endpoint + a lightweight LLM packaged along with the speak activity. Hence I’m making this as a draft PR.