### PR TITLE
Refactor chatbot: Integrating LLM responses in the chabot tab

### DIFF
--- a/brain.py
+++ b/brain.py
@@ -31,6 +31,8 @@ from sugar3 import profile
 from aiml.Kernel import Kernel
 import voice
 
+from llm_brain import get_llm_response, context
+
 import logging
 logger = logging.getLogger('speak')
 
@@ -44,6 +46,7 @@ BOTS = {
                    'predicates': {'name': 'Alice',
                                   'master': 'The Sugar Community'}}}
 
+context = [] # Initialize context
 
 def get_mem_info(tag):
     meminfo = open('/proc/meminfo').readlines()
@@ -84,12 +87,29 @@ def get_default_voice():
         return default_voice
 
 
+def input_routing(text):
+    # Returning false for now to verify LLM response
+    return False
+
+
 def respond(text):
-    if _kernel is not None:
-        text = _kernel.respond(text)
-    if _kernel is None or not text:
-        text = _("Sorry, I can't understand what you are asking about.")
-    return text
+    if input_routing(text) is True:
+        # aiml response
+        if _kernel is not None:
+            text = _kernel.respond(text)
+        if _kernel is None or not text:
+            text = _("Sorry, I can't understand what you are asking about.")
+
+    else:
+        # LLM Response
+        llm_response = get_llm_response(text, context)
+        if llm_response:
+            print(llm_response)
+            context.append(f"You: {text}")
+            context.append(f"LLM: {llm_response}")
+            return llm_response
+        else:
+            return _("Sorry, I can't understand what you are asking about.")
 
 
 def load(activity, voice, sorry=None):

--- a/llm_brain.py
+++ b/llm_brain.py
@@ -1,0 +1,44 @@
+import requests
+
+API_KEY = "Your API KEY"
+API_URL = 'https://api.groq.com/openai/v1/chat/completions' 
+MODEL_NAME = 'llama-3.3-70b-versatile'  
+
+# Initialize context
+context = []
+
+def get_llm_response(prompt, context):
+    headers = {
+        'Authorization': f'Bearer {API_KEY}',
+        'Content-Type': 'application/json'
+    }
+
+    system_prompt = "You are a helpful assistant. You reply with very short answers."
+
+    # Create the messages list
+    messages = [{"role": "system", "content": system_prompt}]
+    messages.extend({"role": "user", "content": msg} for msg in context)
+    messages.append({"role": "user", "content": prompt})
+
+    data = {
+        'model': MODEL_NAME,  
+        'messages': messages,
+        'max_tokens': 150,
+        'temperature': 0.7,
+        'top_p': 1.0,
+        'n': 1
+    }
+
+    response = requests.post(API_URL, headers=headers, json=data)
+
+    if response.status_code == 200:
+        result = response.json()
+        if 'choices' in result and len(result['choices']) > 0:
+            llm_response = result['choices'][0]['message']['content'].strip()
+            return llm_response
+        else:
+            print("Error: No choices found in the response.")
+            return None
+    else:
+        print(f"Error: {response.status_code} - {response.text}")
+        return None


### PR DESCRIPTION
This is a draft implementation to integrate routing of input from the user to the aiml engine(existing) or LLM response based on weather the question is pattern based or complex.
If it returns False then it is routed to the get_llm_response function.
This code successfully integrates LLM response to the chatbot voice and the chat logs. As well as logs the response on the terminal.
It also temporarily saves conversation text for context into further responses.
(This is to verify the code I showed in my GSoC proposal)